### PR TITLE
Default mixin should be low

### DIFF
--- a/src/config/CryptoNoteConfig.h
+++ b/src/config/CryptoNoteConfig.h
@@ -129,11 +129,11 @@ namespace CryptoNote
         /* DEFAULT_MIXIN_V0 is the mixin used before MIXIN_LIMITS_V1_HEIGHT is started */
         const uint64_t DEFAULT_MIXIN_V0 = 3;
 
-        const uint64_t DEFAULT_MIXIN_V1 = MAXIMUM_MIXIN_V1;
+        const uint64_t DEFAULT_MIXIN_V1 = 1;
 
-        const uint64_t DEFAULT_MIXIN_V2 = MAXIMUM_MIXIN_V2;
+        const uint64_t DEFAULT_MIXIN_V2 = 1;
 
-        const uint64_t DEFAULT_MIXIN_V3 = MAXIMUM_MIXIN_V3;
+        const uint64_t DEFAULT_MIXIN_V3 = 3;
 
         const uint64_t DEFAULT_DUST_THRESHOLD = UINT64_C(10);
 


### PR DESCRIPTION
V1 was a bit too much. Low mixin (V1 and V2) helps sending big amount for new coin.